### PR TITLE
Added repository_dispatch function

### DIFF
--- a/toolbelt/apps/release/__init__.py
+++ b/toolbelt/apps/release/__init__.py
@@ -6,6 +6,7 @@ from toolbelt.utils.typer import network_arg, platforms_arg
 
 from .release_player import release as release_player
 from .update_latest_metadata import update as update_latest_metadata
+from .dispatch_action_trigger import dispatch_action_trigger as dispatch
 
 release_app = typer.Typer()
 
@@ -52,4 +53,14 @@ def update_latest(
         commit_hash,
         network,
         slack_channel,
+    )
+
+@release_app.command()
+def action_dispatch(
+    target_repository: str,
+    event_type: Optional[str] = None,
+):
+    dispatch(
+        target_repository,
+        event_type
     )

--- a/toolbelt/apps/release/dispatch_action_trigger.py
+++ b/toolbelt/apps/release/dispatch_action_trigger.py
@@ -6,6 +6,6 @@ from toolbelt.config import config
 
 logger = structlog.get_logger(__name__)
 
-def dispatch_action_trigger(target_repo: str, event_type: str): 
+def dispatch_action_trigger(target_repository: str, event_type: str): 
     github = GithubClient(config.github_token)
-    github.repository_dispatch(target_repo, event_type)
+    github.repository_dispatch(target_repository, event_type)

--- a/toolbelt/apps/release/dispatch_action_trigger.py
+++ b/toolbelt/apps/release/dispatch_action_trigger.py
@@ -1,0 +1,11 @@
+from typing import Optional
+
+import structlog
+from toolbelt.client import GithubClient
+from toolbelt.config import config
+
+logger = structlog.get_logger(__name__)
+
+def dispatch_action_trigger(target_repo: str, event_type: str): 
+    github = GithubClient(config.github_token)
+    github.repository_dispatch(target_repo, event_type)

--- a/toolbelt/client/github.py
+++ b/toolbelt/client/github.py
@@ -202,3 +202,17 @@ class GithubClient:
         response = self.handle_response(r)
 
         return response
+
+    def repository_dispatch(
+            self,
+            *,
+            repo: str,
+            event_type: str,
+    ) -> Any:
+        data = {
+            "event_type": event_type,
+        }
+        r = self._session.post(f"/repos/{self.org}/{repo}/dispatches", json=data)
+        response = self.handle_response(r)
+
+        return response


### PR DESCRIPTION
https://github.com/planetarium/lib9c-wasm/issues/44
https://github.com/planetarium/lib9c-wasm/blob/main/.github/workflows/sync-submodule.yml
In the process of attaching Submodule Bumper on lib9c-wasm, I figured out how to bump lib9c version same as `main` branch of @planetarium/NineChronicles repository, but automate dispatching this action 'on' release, was a bit more hassle.


https://docs.github.com/en/webhooks/webhook-events-and-payloads#repository_dispatch
Github is recommending using Webhook on source repository, but it required specifically generated authentication token. so, between "just shove raw curl line in release action itself", and "Run that sync action periodically", I just made this.

Related Documentation:
https://docs.github.com/en/rest/repos/repos?apiVersion=2022-11-28#create-a-repository-dispatch-event

There's "client_payload" missing in our REST API call, but it was optional and I don't have a good idea handling JSON as input in python. so this was the best I got.

Thanks!